### PR TITLE
Wrap dermacare flow in Firebase handler

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,32 +1,9 @@
-/**
- * Import function triggers from their respective submodules:
- *
- * import {onCall} from "firebase-functions/v2/https";
- * import {onDocumentWritten} from "firebase-functions/v2/firestore";
- *
- * See a full list of supported triggers at https://firebase.google.com/docs/functions
- */
-
 import {setGlobalOptions} from "firebase-functions";
-import {onRequest} from "firebase-functions/https";
-import * as logger from "firebase-functions/logger";
+import {onFlowRequest} from "@genkit-ai/firebase/functions";
 
-// Start writing functions
-// https://firebase.google.com/docs/functions/typescript
+import {dermacareFlow} from "../../src/index.js";
 
-// For cost control, you can set the maximum number of containers that can be
-// running at the same time. This helps mitigate the impact of unexpected
-// traffic spikes by instead downgrading performance. This limit is a
-// per-function limit. You can override the limit for each function using the
-// `maxInstances` option in the function's options, e.g.
-// `onRequest({ maxInstances: 5 }, (req, res) => { ... })`.
-// NOTE: setGlobalOptions does not apply to functions using the v1 API. V1
-// functions should each use functions.runWith({ maxInstances: 10 }) instead.
-// In the v1 API, each function can only serve one request per container, so
-// this will be the maximum concurrent request count.
-setGlobalOptions({ maxInstances: 10 });
+setGlobalOptions({maxInstances: 10});
 
-// export const helloWorld = onRequest((request, response) => {
-//   logger.info("Hello logs!", {structuredData: true});
-//   response.send("Hello from Firebase!");
-// });
+export const dermacare = onFlowRequest(dermacareFlow);
+

--- a/functions/src/types.d.ts
+++ b/functions/src/types.d.ts
@@ -1,0 +1,9 @@
+declare module "@genkit-ai/firebase/functions" {
+  export function onFlowRequest(flow: any): any;
+}
+
+declare module "@gradio/client" {
+  export const Client: any;
+  export const handle_file: any;
+}
+


### PR DESCRIPTION
## Summary
- import dermacareFlow from shared module
- wrap dermacareFlow with Genkit's `onFlowRequest` and export handler
- add ambient module declarations for missing types

## Testing
- `npm --prefix functions run lint`
- `npm --prefix functions run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab5dfbb464832698d9cd5da56338e9