### PR TITLE
feat: add secrets for space base URL and API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# DermalCare AI
+
+## Setting up Secrets
+
+Before deploying the functions, configure the required secrets:
+
+```sh
+firebase functions:secrets:set SPACE_BASE_URL
+firebase functions:secrets:set API_NAME
+firebase functions:secrets:set HF_TOKEN
+```
+
+These commands will prompt for the corresponding values and make them available to your deployed Cloud Functions.

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,9 +1,16 @@
 import {setGlobalOptions} from "firebase-functions";
 import {onFlowRequest} from "@genkit-ai/firebase/functions";
+import {defineSecret} from "firebase-functions/params";
 
 import {dermacareFlow} from "../../src/index.js";
 
 setGlobalOptions({maxInstances: 10});
 
-export const dermacare = onFlowRequest(dermacareFlow);
+const SPACE_BASE_URL = defineSecret("SPACE_BASE_URL");
+const API_NAME = defineSecret("API_NAME");
+const HF_TOKEN = defineSecret("HF_TOKEN");
+
+export const dermacare = onFlowRequest(dermacareFlow, {
+  secrets: [SPACE_BASE_URL, API_NAME, HF_TOKEN],
+});
 

--- a/functions/src/types.d.ts
+++ b/functions/src/types.d.ts
@@ -1,9 +1,11 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 declare module "@genkit-ai/firebase/functions" {
   export function onFlowRequest(flow: any): any;
 }
 
 declare module "@gradio/client" {
   export const Client: any;
+  // eslint-disable-next-line camelcase
   export const handle_file: any;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,11 +32,11 @@ export const dermacareFlow = ai.defineFlow(
     outputSchema: DermacareOutputSchema,
   },
   async ({ question, image }) => {
-    const app = await Client.connect('ColdSlim/DermalCare', {
+    const app = await Client.connect(process.env.SPACE_BASE_URL!, {
       hf_token: process.env.HF_TOKEN,
     });
 
-    const result = await app.predict('/generate_answer', {
+    const result = await app.predict(process.env.API_NAME!, {
       image: image ? handle_file(image) : null,
       question,
       temperature: 0.7,


### PR DESCRIPTION
## Summary
- replace hardcoded Space values with `process.env.SPACE_BASE_URL` and `process.env.API_NAME`
- declare SPACE_BASE_URL, API_NAME and HF_TOKEN as Cloud Function secrets
- document secret setup commands

## Testing
- `npm test` (fails: Error: no test specified)
- `npm --prefix functions run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab60b46bb4832684ae1f5a1a7f11fc