### PR TITLE
chore: enforce LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -13,4 +13,3 @@ const HF_TOKEN = defineSecret("HF_TOKEN");
 export const dermacare = onFlowRequest(dermacareFlow, {
   secrets: [SPACE_BASE_URL, API_NAME, HF_TOKEN],
 });
-

--- a/functions/src/types.d.ts
+++ b/functions/src/types.d.ts
@@ -8,4 +8,3 @@ declare module "@gradio/client" {
   // eslint-disable-next-line camelcase
   export const handle_file: any;
 }
-


### PR DESCRIPTION
## Summary
- add .gitattributes to enforce LF line endings
- trim trailing blank lines in function sources

## Testing
- `npm --prefix functions run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab682658188326bcb0ce180a0f4a35