### PR TITLE
docs: add project setup steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,68 @@
 # DermalCare AI
 
+## Prerequisites
+
+- [Node.js 22](https://nodejs.org/en/download)
+- [Firebase CLI](https://firebase.google.com/docs/cli)
+- [Genkit](https://firebase.google.com/products/genkit)
+
+## Installation
+
+### Root project
+
+```sh
+npm install
+```
+
+### Functions
+
+```sh
+cd functions
+npm install
+```
+
+## Linting
+
+### Root project
+
+```sh
+npm run lint
+```
+
+### Functions
+
+```sh
+npm run lint --prefix functions
+```
+
+## Build
+
+### Root project
+
+```sh
+npm run build
+```
+
+### Functions
+
+```sh
+npm run build --prefix functions
+```
+
+## Deployment
+
+### Root project
+
+```sh
+firebase deploy
+```
+
+### Functions
+
+```sh
+npm run deploy --prefix functions
+```
+
 ## Setting up Secrets
 
 Before deploying the functions, configure the required secrets:
@@ -11,3 +74,8 @@ firebase functions:secrets:set HF_TOKEN
 ```
 
 These commands will prompt for the corresponding values and make them available to your deployed Cloud Functions.
+
+## Troubleshooting
+
+- **Windows line endings:** If scripts fail with `^M` characters on Windows, ensure Git uses LF endings by running `git config core.autocrlf false` and reinstalling dependencies or convert files using `dos2unix`.
+- **TypeScript/ESLint compatibility:** Linting errors may occur if `typescript` and `@typescript-eslint/*` versions mismatch. Align the versions or upgrade both packages to compatible releases.


### PR DESCRIPTION
## Summary
- document prerequisites for Node 22, Firebase CLI, and Genkit
- add install/lint/build/deploy instructions for root project and functions
- add troubleshooting notes for Windows line endings and TS/ESLint version mismatches

## Testing
- `npm --prefix functions run lint`
- `npm --prefix functions run build` *(fails: TS2554 and TS2834 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6897c0088326ad75393535f5eabc