### PR TITLE
Expose secret config via setGlobalOptions

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -4,12 +4,13 @@ import {defineSecret} from "firebase-functions/params";
 
 import {dermacareFlow} from "../../src/index.js";
 
-setGlobalOptions({maxInstances: 10});
-
 const SPACE_BASE_URL = defineSecret("SPACE_BASE_URL");
 const API_NAME = defineSecret("API_NAME");
 const HF_TOKEN = defineSecret("HF_TOKEN");
 
-export const dermacare = onFlowRequest(dermacareFlow, {
+setGlobalOptions({
+  maxInstances: 10,
   secrets: [SPACE_BASE_URL, API_NAME, HF_TOKEN],
 });
+
+export const dermacare = onFlowRequest(dermacareFlow);


### PR DESCRIPTION
## Summary
- configure firebase functions global options to include required secrets
- simplify dermacare function export to use onFlowRequest with only the flow

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm --prefix functions run lint` *(passes with TypeScript version warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6b2f2150832699b00de549a7894a