### PR TITLE
feat: skip third party lib checks to bypass TS2834 errors

### DIFF
--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -3,6 +3,7 @@
     "module": "NodeNext",
     "esModuleInterop": true,
     "moduleResolution": "nodenext",
+    "skipLibCheck": true,
     "noImplicitReturns": true,
     "noUnusedLocals": true,
     "outDir": "lib",


### PR DESCRIPTION
## Summary
- ignore third-party declaration checks with `skipLibCheck`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ab6b35fa408326b2e1f01c36010f37