### PR TITLE
chore: add root build step

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -11,6 +11,7 @@
         "*.local"
       ],
       "predeploy": [
+        "npm run build",
         "npm --prefix \"$RESOURCE_DIR\" run lint",
         "npm --prefix \"$RESOURCE_DIR\" run build"
       ]

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -2,7 +2,7 @@ import {setGlobalOptions} from "firebase-functions";
 import {onFlowRequest} from "@genkit-ai/firebase/functions";
 import {defineSecret} from "firebase-functions/params";
 
-import {dermacareFlow} from "../../src/index.js";
+import {dermacareFlow} from "@src/index";
 
 setGlobalOptions({maxInstances: 10});
 

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -8,7 +8,11 @@
     "outDir": "lib",
     "sourceMap": true,
     "strict": true,
-    "target": "es2017"
+    "target": "es2017",
+    "baseUrl": ".",
+    "paths": {
+      "@src/*": ["../src/*"]
+    }
   },
   "compileOnSave": true,
   "include": [

--- a/package.json
+++ b/package.json
@@ -4,12 +4,13 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "tsc --project tsconfig.json",
     "genkit:ui": "genkit start -- npx tsx --watch src/index.ts"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs",
+  "type": "module",
   "description": "",
   "devDependencies": {
     "cross-env": "^10.0.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -39,6 +39,7 @@
     "isolatedModules": true,
     "noUncheckedSideEffectImports": true,
     "moduleDetection": "force",
-    "skipLibCheck": true,
-  }
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
 }


### PR DESCRIPTION
## Summary
- add TypeScript build script and switch package to ESM
- run root build prior to deploying Cloud Functions
- import TypeScript source from functions using path mapping

## Testing
- `npm run build`
- `npm --prefix functions run build` *(fails: process hung)*
- `npm --prefix functions run lint` *(fails: process hung)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6b38d6cc8326b6f2e0310dad2f12