### PR TITLE
fix: point functions main to compiled index

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -13,7 +13,7 @@
   "engines": {
     "node": "22"
   },
-  "main": "lib/index.js",
+  "main": "lib/src/index.js",
   "dependencies": {
     "@genkit-ai/firebase": "^1.17.0",
     "firebase-admin": "^12.6.0",


### PR DESCRIPTION
## Summary
- align functions package entry to `lib/src/index.js`

## Testing
- `npm --prefix functions run build`
- `ls functions/lib/src`


------
https://chatgpt.com/codex/tasks/task_e_68abd0b3deec8326b0de7e0e8bb8c758