### PR TITLE
fix(functions): point main to built index

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -2,7 +2,7 @@
   "name": "functions",
   "scripts": {
     "lint": "eslint --ext .js,.ts .",
-    "build": "tsc",
+    "build": "tsc && cp lib/functions/src/index.js lib/index.js && cp lib/functions/src/index.js.map lib/index.js.map",
     "build:watch": "tsc --watch",
     "serve": "npm run build && firebase emulators:start --only functions",
     "shell": "npm run build && firebase functions:shell",
@@ -13,7 +13,7 @@
   "engines": {
     "node": "22"
   },
-  "main": "lib/src/index.js",
+  "main": "lib/index.js",
   "dependencies": {
     "@genkit-ai/firebase": "^1.17.0",
     "firebase-admin": "^12.6.0",


### PR DESCRIPTION
## Summary
- point Cloud Functions `main` to `lib/index.js`
- copy compiled function entry to lib root during build

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68abd99b550c83269ccb48fe15e19684