### PR TITLE
chore: target Node 20 for functions

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -11,7 +11,7 @@
     "logs": "firebase functions:log"
   },
   "engines": {
-    "node": "22"
+    "node": "20"
   },
   "main": "lib/src/index.js",
   "dependencies": {


### PR DESCRIPTION
## Summary
- set functions runtime to Node.js 20

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build`
- `npm test` (fails: Error: no test specified)
- `firebase deploy --only functions` (fails: Failed to authenticate, have you run firebase login?)

------
https://chatgpt.com/codex/tasks/task_e_68abd98cf00c8326bf086bde790f336b