### PR TITLE
Add Google AI plugin to Firebase functions

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -11,6 +11,7 @@
         "@genkit-ai/dotprompt": "^0.9.12",
         "@genkit-ai/firebase": "^1.17.1",
         "@genkit-ai/flow": "^0.5.17",
+        "@genkit-ai/googleai": "^1.17.0",
         "firebase-admin": "^12.6.0",
         "firebase-functions": "^6.0.1",
         "genkit": "^1.17.0",
@@ -1149,6 +1150,38 @@
         "url": "https://opencollective.com/node-fetch"
       }
     },
+    "node_modules/@genkit-ai/googleai": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@genkit-ai/googleai/-/googleai-1.17.1.tgz",
+      "integrity": "sha512-OQjPw5+z+OvknfWVDk8Mj7W7/zZJLPYyTPHjN9hiWnaVqFpcXF+QEY7fbfIW0kUS+4ealrAPlzM2/6XUSWw90w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@google/generative-ai": "^0.24.0",
+        "google-auth-library": "^9.6.3",
+        "node-fetch": "^3.3.2"
+      },
+      "peerDependencies": {
+        "genkit": "^1.17.1"
+      }
+    },
+    "node_modules/@genkit-ai/googleai/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
     "node_modules/@google-cloud/common": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-5.0.2.tgz",
@@ -1376,6 +1409,15 @@
       "optional": true,
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@google/generative-ai": {
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.24.1.tgz",
+      "integrity": "sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@grpc/grpc-js": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -19,6 +19,7 @@
     "@genkit-ai/core": "^1.17.1",
     "@genkit-ai/dotprompt": "^0.9.12",
     "@genkit-ai/firebase": "^1.17.1",
+    "@genkit-ai/googleai": "^1.17.0",
     "@genkit-ai/flow": "^0.5.17",
     "firebase-admin": "^12.6.0",
     "firebase-functions": "^6.0.1",


### PR DESCRIPTION
## Summary
- add `@genkit-ai/googleai` dependency to functions package
- reinstall functions dependencies for a single Genkit installation

## Testing
- `npm install`
- `npm run build`
- `firebase deploy --only functions` *(fails: Failed to authenticate, have you run firebase login?)*

------
https://chatgpt.com/codex/tasks/task_e_68abfbcddba883268a183c831e84bfff