### PR TITLE
refactor: replace onFlowRequest with onRequest

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,5 +1,5 @@
 import {setGlobalOptions} from "firebase-functions";
-import {onFlowRequest} from "@genkit-ai/firebase/functions";
+import {onRequest} from "firebase-functions/v2/https";
 import {defineSecret} from "firebase-functions/params";
 
 import {dermacareFlow} from "./flow";
@@ -13,4 +13,7 @@ setGlobalOptions({
   secrets: [SPACE_BASE_URL, API_NAME, HF_TOKEN],
 });
 
-export const dermacare = onFlowRequest(dermacareFlow);
+export const dermacare = onRequest(async (req, res) => {
+  const result = await dermacareFlow(req.body);
+  res.json(result);
+});

--- a/functions/src/types.d.ts
+++ b/functions/src/types.d.ts
@@ -1,7 +1,4 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-declare module "@genkit-ai/firebase/functions" {
-  export function onFlowRequest(flow: any): any;
-}
 
 declare module "@gradio/client" {
   export const Client: any;


### PR DESCRIPTION
## Summary
- replace Genkit `onFlowRequest` with Firebase `onRequest`
- remove custom `@genkit-ai/firebase/functions` module declarations

## Testing
- `npm run build`
- `firebase deploy --only functions` *(fails: Failed to authenticate, have you run firebase login?)*

------
https://chatgpt.com/codex/tasks/task_e_68ac045dec2c8326bc8d7e6f39ca79d3