### PR TITLE
fix: correct CORS origins for Firebase function

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -5,8 +5,14 @@ import {dermacareFlow} from "./flow";
 import {setGlobalOptions} from "firebase-functions";
 import cors from "cors";
 
+const allowedOrigins = [
+  "https://dermalcare-69.web.app",
+  "https://dermalcare-69.firebaseapp.com",
+  "http://localhost:3000",
+];
+
 const corsHandler = cors({
-  origin: ["https://dermalcare-69.web.app/", "http://localhost:3000"],
+  origin: allowedOrigins,
   methods: ["POST", "OPTIONS"],
   allowedHeaders: ["Authorization", "Content-Type"],
 });


### PR DESCRIPTION
## Summary
- allow Firebase hosting domains in CORS configuration
- keep dev origin localhost:3000

## Testing
- `npm run build`
- `npm --prefix functions run lint`
- `npm --prefix functions run build`


------
https://chatgpt.com/codex/tasks/task_e_68afbea2a3bc8326a3e6c69619b61b1f