### PR TITLE
Log rejected origins before unauthorized responses

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -5,8 +5,12 @@ import {dermacareFlow} from "./flow";
 import {setGlobalOptions} from "firebase-functions";
 import cors from "cors";
 
+const allowedOrigins = [
+  "https://dermalcare-69.web.app/",
+  "http://localhost:3000",
+];
 const corsHandler = cors({
-  origin: ["https://dermalcare-69.web.app/", "http://localhost:3000"],
+  origin: allowedOrigins,
   methods: ["POST", "OPTIONS"],
   allowedHeaders: ["Authorization", "Content-Type"],
 });
@@ -20,6 +24,24 @@ export const dermacare = onRequest((req, res) => {
   corsHandler(req, res, async () => {
     if (req.method === "OPTIONS") {
       res.status(204).send("");
+      return;
+    }
+
+    const origin = req.headers.origin;
+    if (!origin) {
+      console.warn("Missing Origin header:", origin);
+      res.status(401).json({
+        error: "No origin",
+        details: "Origin header is missing.",
+      });
+      return;
+    }
+    if (!allowedOrigins.includes(origin)) {
+      console.warn("Rejected request from origin:", origin);
+      res.status(403).json({
+        error: "Forbidden",
+        details: "Origin not allowed.",
+      });
       return;
     }
 


### PR DESCRIPTION
## Summary
- log missing or disallowed request origins before returning 401/403 in Dermacare Cloud Function

## Testing
- `npm run lint` *(fails: Unknown env config "http-proxy" warning but runs without issues)*
- `npm run build`
- `npx firebase-tools deploy --only functions` *(fails: SyntaxError parsing package.json for firebase-tools)*

------
https://chatgpt.com/codex/tasks/task_e_68afbfeba708832684c14587cce2ef20